### PR TITLE
improve a11y by adding roles and aria-labels at various places

### DIFF
--- a/src/main/js/bundles/dn_geoprocessing/GeoprocessingParameterInputWidget.vue
+++ b/src/main/js/bundles/dn_geoprocessing/GeoprocessingParameterInputWidget.vue
@@ -45,7 +45,10 @@
             <v-stepper-items class="fill-height">
                 <v-stepper-content step="1">
                     <div class="geoprocessing--parameters">
-                        <v-form v-model="valid">
+                        <v-form
+                            v-model="valid"
+                            :aria-label="i18n.parametersTab"
+                        >
                             <div
                                 v-for="(param) in parametersWithRules"
                                 :key="param.id"
@@ -147,12 +150,16 @@
                             :size="50"
                             color="primary"
                             indeterminate
+                            role="alert"
+                            aria-busy="true"
+                            :aria-label="i18n.processingInProgress"
                         />
                     </div>
                     <div class="geoprocessing--alert">
                         <v-alert
                             v-if="resultState==='success'"
                             :value="true"
+                            role="alert"
                             type="success"
                         >
                             {{ i18n.success }}
@@ -160,6 +167,7 @@
                         <v-alert
                             v-if="resultState==='error'"
                             :value="true"
+                            role="alert"
                             type="error"
                         >
                             {{ i18n.error }} <a :href="supportContact">{{ supportEmailAddress }}</a>!

--- a/src/main/js/bundles/dn_geoprocessing/GeoprocessingToolsWidget.vue
+++ b/src/main/js/bundles/dn_geoprocessing/GeoprocessingToolsWidget.vue
@@ -49,6 +49,7 @@
                 <v-alert
                     v-if="resultState==='success'"
                     :value="true"
+                    role="alert"
                     type="success"
                 >
                     {{ i18n.success }}
@@ -56,6 +57,7 @@
                 <v-alert
                     v-if="resultState==='error'"
                     :value="true"
+                    role="alert"
                     type="error"
                 >
                     {{ i18n.error }} <a :href="supportContact">{{ supportEmailAddress }}</a>!

--- a/src/main/js/bundles/dn_geoprocessing/nls/bundle.js
+++ b/src/main/js/bundles/dn_geoprocessing/nls/bundle.js
@@ -31,6 +31,9 @@ module.exports = {
                 x: "Easting",
                 y: "Northing"
             },
+            selectCenterOnMap: "Select center coordinate on map",
+            processingInProgress: "Request in progress",
+            parametersForm: "Form for geoprocessing parameters",
             resultsTab: "Results",
             executeButtonLabel: "Execute",
             result: "Result",

--- a/src/main/js/bundles/dn_geoprocessing/nls/de/bundle.js
+++ b/src/main/js/bundles/dn_geoprocessing/nls/de/bundle.js
@@ -28,10 +28,13 @@ module.exports = {
         success: "Geoprocessing erfolgreich abgeschlossen.",
         error: "Es ist ein Fehler aufgetreten, bitte wenden Sie sich an",
         parametersTab: "Parameter",
+        parametersForm: "Formular zur Eingabe der Geoprocessing-Parameter",
         parameters: {
             x: "Rechtswert",
             y: "Hochwert"
         },
+        selectCenterOnMap: "Mittelpunktkoordinate auf der Karte auswählen",
+        processingInProgress: "Die Abfrage läuft",
         resultsTab: "Ergebnisse",
         executeButtonLabel: "Ausführen",
         result: "Ergebnis",

--- a/src/main/js/bundles/dn_geoprocessing/templates/GPFeatureRecordSetLayerInput.vue
+++ b/src/main/js/bundles/dn_geoprocessing/templates/GPFeatureRecordSetLayerInput.vue
@@ -52,6 +52,7 @@
                 color="primary"
                 :disabled="!editable"
                 :class="clickWatcherActive ? 'parameterInput__coordinate-entry-button--active' : ''"
+                :aria-label="i18n.selectCenterOnMap"
                 @click="handleLocationButtonClick"
             >
                 <v-icon>


### PR DESCRIPTION
In order to achieve a better accessibility (especially for Screenreader users) I've added aria-labels and some role attributes to let the screenreader read out the status of a geoprocessing request.
Furthermore, some aria-labels were added where needed.